### PR TITLE
refactor: move valores array outside component

### DIFF
--- a/src/features/acerca/Acerca.jsx
+++ b/src/features/acerca/Acerca.jsx
@@ -7,8 +7,14 @@ import { Link } from 'react-router-dom';
 import uiStyles from '../../styles/ui.module.css';
 import styles from '../../styles/acerca.module.css';
 
+const valores = [
+  "Transparencia",
+  "Accesibilidad",
+  "Confiabilidad",
+  "Sostenibilidad"
+];
+
 const Acerca = () => {
-  const valores = ["Transparencia", "Accesibilidad", "Confiabilidad", "Sostenibilidad"];
 
   return (
     <main>


### PR DESCRIPTION
## Summary
- define `valores` array at module scope in Acerca feature
- keep component logic referencing `valores`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh/only-export-components in existing files)*
- `npx eslint src/features/acerca/Acerca.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a809d8e6448330bba9a80d16715fe7