### PR TITLE
chore: add aria label to progress bar

### DIFF
--- a/src/features/acerca/Acerca.jsx
+++ b/src/features/acerca/Acerca.jsx
@@ -69,13 +69,14 @@ const Acerca = () => {
               <h3>Próximas expansiones</h3>
               <p>Estamos trabajando para ampliar nuestra cobertura a 10 comunidades adicionales para finales del próximo año.</p>
               <div className={styles.progressBar}>
-                <div 
-                  className={styles.progressFill} 
+                <div
+                  className={styles.progressFill}
                   style={{ width: '60%' }}
                   role="progressbar"
                   aria-valuenow={60}
                   aria-valuemin="0"
                   aria-valuemax="100"
+                  aria-label="Porcentaje de comunidades adicionales cubiertas"
                 ></div>
               </div>
               <p className={styles.progressText}>60% de la meta de expansión alcanzada</p>


### PR DESCRIPTION
## Summary
- add accessible aria-label to progress bar on Acerca page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react-refresh/only-export-components in contexts)*
- `npx eslint src/features/acerca/Acerca.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a809ef71108330bceca305bdef282d