### PR TITLE
refactor(acerca): modularize about page

### DIFF
--- a/src/features/acerca/Acerca.jsx
+++ b/src/features/acerca/Acerca.jsx
@@ -1,123 +1,27 @@
 /**
  * Feature: Acerca
- * This is the Acerca feature; it contains the about page with information about the application.
+ * This is the Acerca feature; it composes the about page with information about the application.
  */
 import React from 'react';
-import { Link } from 'react-router-dom';
 import uiStyles from '../../styles/ui.module.css';
-import styles from '../../styles/acerca.module.css';
+import Hero from './components/Hero';
+import Proposito from './components/Proposito';
+import Objetivos from './components/Objetivos';
+import Cobertura from './components/Cobertura';
+import Valores from './components/Valores';
+import CTA from './components/CTA';
 
-const valores = [
-  "Transparencia",
-  "Accesibilidad",
-  "Confiabilidad",
-  "Sostenibilidad"
-];
-
-const Acerca = () => {
-
-  return (
-    <main>
-      {/* Hero Section */}
-      <section className={styles.hero}>
-        <div className={styles.heroContent}>
-          <h1>Sobre App_Rural</h1>
-          <p>Transparencia y monitoreo para sistemas de agua potable rurales.</p>
-        </div>
-      </section>
-
-      <div className={uiStyles.container}>
-        {/* Propósito Section */}
-        <section className={styles.section}>
-          <div className={styles.card}>
-            <h2>Propósito</h2>
-            <p>
-              Nuestra misión es facilitar el monitoreo continuo de sistemas de agua potable en zonas rurales, 
-              proporcionando datos confiables para la toma de decisiones informadas que garanticen la continuidad 
-              del servicio y la calidad del agua para las comunidades.
-            </p>
-          </div>
-        </section>
-
-        {/* Objetivos Section */}
-        <section className={styles.section}>
-          <h2>Nuestros Objetivos</h2>
-          <div className={styles.gridThree}>
-            <div className={styles.card}>
-              <h3>Monitoreo continuo</h3>
-              <p>Métricas clave en tiempo real para el seguimiento de la calidad y disponibilidad del agua.</p>
-            </div>
-            <div className={uiStyles.card}>
-              <h3>Alertas tempranas</h3>
-              <p>Sistema de notificaciones para la prevención y respuesta rápida ante posibles problemas.</p>
-            </div>
-            <div className={uiStyles.card}>
-              <h3>Eficiencia operativa</h3>
-              <p>Herramientas de soporte para operarios y Juntas Administradoras de Agua (JAA).</p>
-            </div>
-          </div>
-        </section>
-
-        {/* Cobertura Section */}
-        <section className={styles.section}>
-          <h2>Cobertura</h2>
-          <div className={styles.gridTwo}>
-            <div className={styles.card}>
-              <h3>Áreas de impacto</h3>
-              <p>Actualmente operamos en 15 comunidades rurales de la región, beneficiando a más de 5,000 familias.</p>
-              <ul className={styles.coberturaList}>
-                <li>Monitoreo de 12 plantas de tratamiento</li>
-                <li>25 sistemas de distribución</li>
-                <li>10 fuentes de agua protegidas</li>
-              </ul>
-            </div>
-            <div className={styles.card}>
-              <h3>Próximas expansiones</h3>
-              <p>Estamos trabajando para ampliar nuestra cobertura a 10 comunidades adicionales para finales del próximo año.</p>
-              <div className={styles.progressBar}>
-                <div
-                  className={styles.progressFill}
-                  style={{ width: '60%' }}
-                  role="progressbar"
-                  aria-valuenow={60}
-                  aria-valuemin="0"
-                  aria-valuemax="100"
-                  aria-label="Porcentaje de comunidades adicionales cubiertas"
-                ></div>
-              </div>
-              <p className={styles.progressText}>60% de la meta de expansión alcanzada</p>
-            </div>
-          </div>
-        </section>
-
-        {/* Valores Section */}
-        <section className={styles.section}>
-          <h2>Nuestros Valores</h2>
-          <div className={styles.chipsContainer}>
-            {valores.map((valor, index) => (
-              <span key={index} className={styles.chip}>
-                {valor}
-              </span>
-            ))}
-          </div>
-        </section>
-
-        {/* CTA Section */}
-        <section className={styles.ctaSection}>
-          <h2>¿Listo para comenzar?</h2>
-          <p>Únete a nuestra plataforma y comienza a monitorear la calidad del agua en tu comunidad.</p>
-          <div className={styles.ctaButtons}>
-            <Link to="/registro" className={uiStyles.btnPrimary}>
-              Crear cuenta
-            </Link>
-            <Link to="/contacto" className={uiStyles.btnOutline}>
-              Contáctanos
-            </Link>
-          </div>
-        </section>
-      </div>
-    </main>
-  );
-};
+const Acerca = () => (
+  <main>
+    <Hero />
+    <div className={uiStyles.container}>
+      <Proposito />
+      <Objetivos />
+      <Cobertura />
+      <Valores />
+      <CTA />
+    </div>
+  </main>
+);
 
 export default Acerca;

--- a/src/features/acerca/components/CTA.jsx
+++ b/src/features/acerca/components/CTA.jsx
@@ -1,0 +1,24 @@
+/**
+ * CTA section for the Acerca page.
+ */
+import React from 'react';
+import { Link } from 'react-router-dom';
+import uiStyles from '../../../styles/ui.module.css';
+import styles from '../../../styles/acerca.module.css';
+
+const CTA = () => (
+  <section className={styles.ctaSection}>
+    <h2>¿Listo para comenzar?</h2>
+    <p>Únete a nuestra plataforma y comienza a monitorear la calidad del agua en tu comunidad.</p>
+    <div className={styles.ctaButtons}>
+      <Link to="/registro" className={uiStyles.btnPrimary}>
+        Crear cuenta
+      </Link>
+      <Link to="/contacto" className={uiStyles.btnOutline}>
+        Contáctanos
+      </Link>
+    </div>
+  </section>
+);
+
+export default CTA;

--- a/src/features/acerca/components/Cobertura.jsx
+++ b/src/features/acerca/components/Cobertura.jsx
@@ -1,0 +1,40 @@
+/**
+ * Cobertura section for the Acerca page.
+ */
+import React from 'react';
+import styles from '../../../styles/acerca.module.css';
+
+const Cobertura = () => (
+  <section className={styles.section}>
+    <h2>Cobertura</h2>
+    <div className={styles.gridTwo}>
+      <div className={styles.card}>
+        <h3>Áreas de impacto</h3>
+        <p>Actualmente operamos en 15 comunidades rurales de la región, beneficiando a más de 5,000 familias.</p>
+        <ul className={styles.coberturaList}>
+          <li>Monitoreo de 12 plantas de tratamiento</li>
+          <li>25 sistemas de distribución</li>
+          <li>10 fuentes de agua protegidas</li>
+        </ul>
+      </div>
+      <div className={styles.card}>
+        <h3>Próximas expansiones</h3>
+        <p>Estamos trabajando para ampliar nuestra cobertura a 10 comunidades adicionales para finales del próximo año.</p>
+        <div className={styles.progressBar}>
+          <div
+            className={styles.progressFill}
+            style={{ width: '60%' }}
+            role="progressbar"
+            aria-valuenow={60}
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="Porcentaje de comunidades adicionales cubiertas"
+          ></div>
+        </div>
+        <p className={styles.progressText}>60% de la meta de expansión alcanzada</p>
+      </div>
+    </div>
+  </section>
+);
+
+export default Cobertura;

--- a/src/features/acerca/components/Hero.jsx
+++ b/src/features/acerca/components/Hero.jsx
@@ -1,0 +1,16 @@
+/**
+ * Hero section for the Acerca page.
+ */
+import React from 'react';
+import styles from '../../../styles/acerca.module.css';
+
+const Hero = () => (
+  <section className={styles.hero}>
+    <div className={styles.heroContent}>
+      <h1>Sobre App_Rural</h1>
+      <p>Transparencia y monitoreo para sistemas de agua potable rurales.</p>
+    </div>
+  </section>
+);
+
+export default Hero;

--- a/src/features/acerca/components/Objetivos.jsx
+++ b/src/features/acerca/components/Objetivos.jsx
@@ -1,0 +1,28 @@
+/**
+ * Objetivos section for the Acerca page.
+ */
+import React from 'react';
+import uiStyles from '../../../styles/ui.module.css';
+import styles from '../../../styles/acerca.module.css';
+
+const Objetivos = () => (
+  <section className={styles.section}>
+    <h2>Nuestros Objetivos</h2>
+    <div className={styles.gridThree}>
+      <div className={styles.card}>
+        <h3>Monitoreo continuo</h3>
+        <p>Métricas clave en tiempo real para el seguimiento de la calidad y disponibilidad del agua.</p>
+      </div>
+      <div className={uiStyles.card}>
+        <h3>Alertas tempranas</h3>
+        <p>Sistema de notificaciones para la prevención y respuesta rápida ante posibles problemas.</p>
+      </div>
+      <div className={uiStyles.card}>
+        <h3>Eficiencia operativa</h3>
+        <p>Herramientas de soporte para operarios y Juntas Administradoras de Agua (JAA).</p>
+      </div>
+    </div>
+  </section>
+);
+
+export default Objetivos;

--- a/src/features/acerca/components/Proposito.jsx
+++ b/src/features/acerca/components/Proposito.jsx
@@ -1,0 +1,20 @@
+/**
+ * Propósito section for the Acerca page.
+ */
+import React from 'react';
+import styles from '../../../styles/acerca.module.css';
+
+const Proposito = () => (
+  <section className={styles.section}>
+    <div className={styles.card}>
+      <h2>Propósito</h2>
+      <p>
+        Nuestra misión es facilitar el monitoreo continuo de sistemas de agua potable en zonas rurales,
+        proporcionando datos confiables para la toma de decisiones informadas que garanticen la continuidad
+        del servicio y la calidad del agua para las comunidades.
+      </p>
+    </div>
+  </section>
+);
+
+export default Proposito;

--- a/src/features/acerca/components/Valores.jsx
+++ b/src/features/acerca/components/Valores.jsx
@@ -1,0 +1,27 @@
+/**
+ * Valores section for the Acerca page.
+ */
+import React from 'react';
+import styles from '../../../styles/acerca.module.css';
+
+const valores = [
+  'Transparencia',
+  'Accesibilidad',
+  'Confiabilidad',
+  'Sostenibilidad',
+];
+
+const Valores = () => (
+  <section className={styles.section}>
+    <h2>Nuestros Valores</h2>
+    <div className={styles.chipsContainer}>
+      {valores.map((valor, index) => (
+        <span key={index} className={styles.chip}>
+          {valor}
+        </span>
+      ))}
+    </div>
+  </section>
+);
+
+export default Valores;


### PR DESCRIPTION
## Summary
- split Acerca page into Hero, Proposito, Objetivos, Cobertura, Valores, and CTA components
- compose Acerca feature from new modular components

## Testing
- `npx eslint src/features/acerca`


------
https://chatgpt.com/codex/tasks/task_e_68a80c73b9e88330a55673c9daf7d151