### PR TITLE
Handle caudalDiseno in dashboard normalization

### DIFF
--- a/src/features/dashboard/Dashboard.jsx
+++ b/src/features/dashboard/Dashboard.jsx
@@ -7,7 +7,7 @@ import plantasData from '../../data/plantas.json';
 const normalizePlantasData = (data) => {
   return data.map(planta => ({
     ...planta,
-    caudalDiseño: parseFloat((planta.caudalDiseño || planta.caudaDiseño || 0).toString().replace(',', '.')) || 0,
+    caudalDiseño: parseFloat((planta.caudalDiseño || planta.caudalDiseno || planta.caudaDiseño || 0).toString().replace(',', '.')) || 0,
     usuarios: parseInt(planta.usuarios || 0, 10) || 0
   }));
 };


### PR DESCRIPTION
## Summary
- Normalize dashboard data to include `caudalDiseno`
- Confirm KPIs and charts read normalized `caudalDiseño` values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*

------
https://chatgpt.com/codex/tasks/task_e_68a80d914ec48330abc64fbcec3a8271