### PR TITLE
refactor: simplify filter options

### DIFF
--- a/src/features/dashboard/Dashboard.jsx
+++ b/src/features/dashboard/Dashboard.jsx
@@ -62,10 +62,19 @@ const Dashboard = () => {
   });
 
   // Get unique filter options
-  const filterOptions = useMemo(() => ({
-    corregimiento: [...new Set(normalizedData.map(p => p.corregimiento).filter(Boolean))].sort(),
-    fuente: [...new Set(normalizedData.map(p => p.fuente).filter(Boolean))].sort()
-  }), [normalizedData]);
+  const filterOptions = useMemo(() => {
+    const corregimientos = Array.from(
+      new Set(normalizedData.map(p => p.corregimiento))
+    );
+    const fuentes = Array.from(
+      new Set(normalizedData.map(p => p.fuente))
+    );
+
+    return {
+      corregimiento: corregimientos.filter(Boolean).sort(),
+      fuente: fuentes.filter(Boolean).sort()
+    };
+  }, [normalizedData]);
 
   // Apply filters to data
   const filteredData = useMemo(() => 


### PR DESCRIPTION
## Summary
- remove empty-string placeholder from filter options and rely on Set for unique values
- keep a single `<option value="">` placeholder in `FilterSelect`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react-refresh/only-export-components errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a80ffb4ccc83308cd04d46b16171d5