### PR TITLE
Refactor auth flow with signIn/signUp

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -33,12 +33,16 @@ export const AuthProvider = ({ children }) => {
     setIsInitialized(true);
   }, []);
 
-  const login = ({ email, role = ROLES.USUARIO, name }) => {
+  const signIn = ({ email, role = ROLES.USUARIO, name }) => {
     const userObj = { name: name || email.split('@')[0], email, role };
     setUser(userObj);
     setRole(role);
     localStorage.setItem(USER_KEY, JSON.stringify(userObj));
     localStorage.setItem(ROLE_STORAGE_KEY, role);
+  };
+
+  const signUp = ({ name, email, role = ROLES.USUARIO }) => {
+    signIn({ email, role, name });
   };
 
   const signOut = () => {
@@ -64,7 +68,7 @@ export const AuthProvider = ({ children }) => {
   }
 
   return (
-    <AuthContext.Provider value={{ user, role, login, signOut, updateRole, ROLES }}>
+    <AuthContext.Provider value={{ user, role, signIn, signUp, signOut, updateRole, ROLES }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/features/auth/components/LoginForm.jsx
+++ b/src/features/auth/components/LoginForm.jsx
@@ -8,7 +8,7 @@ function validateEmail(email) {
 }
 
 export default function LoginForm() {
-  const { login } = useAuth();
+  const { signIn } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -31,8 +31,7 @@ export default function LoginForm() {
     setTimeout(() => {
       // Simular sign-in
       const user = { email, role: 'user' };
-      login(user);
-      localStorage.setItem('app_rural_user', JSON.stringify(user));
+      signIn(user);
       // Redirigir
       const redirectTo = location.state?.from?.pathname || '/dashboard';
       navigate(redirectTo, { replace: true });

--- a/src/features/auth/components/SignupForm.jsx
+++ b/src/features/auth/components/SignupForm.jsx
@@ -15,7 +15,7 @@ const ROLES = [
 ];
 
 export default function SignupForm() {
-  const { login } = useAuth();
+  const { signIn, signUp } = useAuth();
   const [nombre, setNombre] = useState('');
   const [email, setEmail] = useState('');
   const [rol, setRol] = useState('USUARIO');
@@ -47,9 +47,9 @@ export default function SignupForm() {
     setLoading(true);
     setTimeout(() => {
       // Simular registro y login
-      const user = { nombre, email, rol };
-      login(user);
-      localStorage.setItem('app_rural_user', JSON.stringify(user));
+      const user = { name: nombre, email, role: rol };
+      signUp(user);
+      signIn(user);
       navigate('/dashboard', { replace: true });
     }, 700);
   };


### PR DESCRIPTION
## Summary
- Replace login usage with signIn in login and signup forms
- Add signUp helper and expose signIn/signUp from AuthContext
- Rely on AuthContext for localStorage to keep keys consistent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a827700c948330ad1375dc64303c96