### PR TITLE
Reemplaza botón de Conocer más por Link

### DIFF
--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -34,9 +34,9 @@ const Home = () => {
             <Link to="/dashboard" className={uiStyles.btnPrimary}>
               Ir al Dashboard
             </Link>
-            <button type="button" className={uiStyles.btnGhost}>
+            <Link to="/acerca" className={uiStyles.btnGhost}>
               Conocer más
-            </button>
+            </Link>
           </div>
           
           <div className={styles.kpiRow}>


### PR DESCRIPTION
## Summary
- Sustituye el botón "Conocer más" por un `Link` que navega a `/acerca`

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8293553508330a9f485af2726eb26