### PR TITLE
refactor: move kpi data outside Home component

### DIFF
--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -9,14 +9,14 @@ import KpiCard from './components/KpiCard';
 import styles from '../../styles/home.module.css';
 import uiStyles from '../../styles/ui.module.css';
 
-const Home = () => {
-  // Datos mock para las tarjetas KPI
-  const kpiData = [
-    { value: '98%', label: 'Calidad OK' },
-    { value: '24/7', label: 'Monitoreo' },
-    { value: '1.2K', label: 'Usuarios' },
-  ];
+// Datos mock para las tarjetas KPI
+const kpiData = [
+  { value: '98%', label: 'Calidad OK' },
+  { value: '24/7', label: 'Monitoreo' },
+  { value: '1.2K', label: 'Usuarios' },
+];
 
+const Home = () => {
   return (
     <div className={styles.hero}>
       <WaveBackground />
@@ -40,9 +40,9 @@ const Home = () => {
           </div>
           
           <div className={styles.kpiRow}>
-            {kpiData.map((kpi, index) => (
-              <KpiCard 
-                key={index}
+            {kpiData.map((kpi) => (
+              <KpiCard
+                key={kpi.label}
                 value={kpi.value}
                 label={kpi.label}
               />


### PR DESCRIPTION
## Summary
- move KPI data outside Home component
- use KPI label as stable key

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a829fd6e648330a33f4b758d1e612a