### PR TITLE
feat: normalize caudalDiseno variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --port 5173 --strictPort",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/src/features/plantas/Plantas.jsx
+++ b/src/features/plantas/Plantas.jsx
@@ -1,36 +1,7 @@
 import React, { useMemo, useState } from "react";
 import plantasRaw from "@data/plantas.json";
 import styles from "./plantas.module.css";
-
-function toNumber(v) {
-  if (v === null || v === undefined) return null;
-  const s = String(v).replace(",", ".");
-  const n = Number(s);
-  return Number.isFinite(n) ? n : null;
-}
-
-function normalizePlant(p) {
-  return {
-    id: String(p.id ?? p.planta ?? ""),
-    planta: p.planta ?? p.nombre ?? "Planta",
-    nombre: p.nombre ?? p.planta ?? "",
-    vereda: p.vereda ?? "",
-    corregimiento: p.corregimiento ?? "",
-    fuente: p.fuente ?? "",
-    tipoAgua: p.tipoAgua ?? p["tipoAgua"] ?? "",
-    tipoPlanta: p.tipoPlanta ?? "",
-    conduccion: p.conduccion ?? "",
-    tanqueAbastec: p.tanqueAbastec ?? p["tanqueAbastec."] ?? "",
-    desarenador: p.desarenador ?? "",
-    desinfeccion: p.desinfeccion ?? "",
-    caudalDiseno: toNumber(p.caudaDiseño ?? p.caudalDiseño),
-    caudalConcesion: toNumber(p.caudalConcesion ?? p["caudalConcesion "]),
-    usuarios: toNumber(p.usuarios),
-    poblacion: toNumber(p.poblacion ?? p["Población"]),
-    lat: toNumber(p.lat ?? p.latitud),
-    lng: toNumber(p.lng ?? p.longitud),
-  };
-}
+import { normalizePlant } from "./normalizePlant.js";
 
 export default function Plantas() {
   const [selectedId, setSelectedId] = useState("");

--- a/src/features/plantas/normalizePlant.js
+++ b/src/features/plantas/normalizePlant.js
@@ -1,0 +1,29 @@
+export function toNumber(v) {
+  if (v === null || v === undefined) return null;
+  const s = String(v).replace(",", ".");
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function normalizePlant(p) {
+  return {
+    id: String(p.id ?? p.planta ?? ""),
+    planta: p.planta ?? p.nombre ?? "Planta",
+    nombre: p.nombre ?? p.planta ?? "",
+    vereda: p.vereda ?? "",
+    corregimiento: p.corregimiento ?? "",
+    fuente: p.fuente ?? "",
+    tipoAgua: p.tipoAgua ?? p["tipoAgua"] ?? "",
+    tipoPlanta: p.tipoPlanta ?? "",
+    conduccion: p.conduccion ?? "",
+    tanqueAbastec: p.tanqueAbastec ?? p["tanqueAbastec."] ?? "",
+    desarenador: p.desarenador ?? "",
+    desinfeccion: p.desinfeccion ?? "",
+    caudalDiseno: toNumber(p.caudaDiseño ?? p.caudalDiseño ?? p.caudalDiseno),
+    caudalConcesion: toNumber(p.caudalConcesion ?? p["caudalConcesion "]),
+    usuarios: toNumber(p.usuarios),
+    poblacion: toNumber(p.poblacion ?? p["Población"]),
+    lat: toNumber(p.lat ?? p.latitud),
+    lng: toNumber(p.lng ?? p.longitud),
+  };
+}

--- a/src/features/plantas/normalizePlant.test.js
+++ b/src/features/plantas/normalizePlant.test.js
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { toNumber, normalizePlant } from './normalizePlant.js';
+
+test('toNumber converts strings to numbers and handles commas', () => {
+  assert.equal(toNumber('10'), 10);
+  assert.equal(toNumber('10,5'), 10.5);
+  assert.equal(toNumber('10.5'), 10.5);
+  assert.equal(toNumber(null), null);
+  assert.equal(toNumber(undefined), null);
+  assert.equal(toNumber('abc'), null);
+});
+
+test('normalizePlant resolves caudalDiseno from multiple fields', () => {
+  assert.equal(normalizePlant({ caudaDiseño: '1,2' }).caudalDiseno, 1.2);
+  assert.equal(normalizePlant({ caudalDiseño: '2' }).caudalDiseno, 2);
+  assert.equal(normalizePlant({ caudalDiseno: '3' }).caudalDiseno, 3);
+});


### PR DESCRIPTION
## Summary
- include `caudalDiseno` alias when normalizing plant data
- expose normalization helpers for reuse and testing
- add unit tests for `toNumber` and `normalizePlant`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82b451784833087c822fef9cc24aa