### PR TITLE
Add noopener to Google Maps link

### DIFF
--- a/src/features/plantas/Plantas.jsx
+++ b/src/features/plantas/Plantas.jsx
@@ -50,7 +50,7 @@ export default function Plantas() {
           <header className={styles.header}>
             <h2 className={styles.cardTitle}>{selected.planta}</h2>
             {mapHref && (
-              <a className={styles.mapLink} href={mapHref} target="_blank" rel="noreferrer">
+              <a className={styles.mapLink} href={mapHref} target="_blank" rel="noreferrer noopener">
                 📍 Ver en mapa
               </a>
             )}


### PR DESCRIPTION
## Summary
- Improve security by adding `noopener` to the Google Maps link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82c102e548330a843c3b8b3cedecc