### PR TITLE
Añade aria-label al indicador de nivel del tanque

### DIFF
--- a/src/features/plantas/detail/PlantDetail.jsx
+++ b/src/features/plantas/detail/PlantDetail.jsx
@@ -169,10 +169,11 @@ const PlantDetail = () => {
               <div className={styles.statusCard}>
                 <h4>Tanque de Almacenamiento</h4>
                 <div className={styles.progressContainer}>
-                  <div 
-                    className={styles.progressBar} 
+                  <div
+                    className={styles.progressBar}
                     style={{ width: `${plant.nivel_tanque || 0}%` }}
                     role="progressbar"
+                    aria-label="Nivel del tanque"
                     aria-valuenow={plant.nivel_tanque || 0}
                     aria-valuemin="0"
                     aria-valuemax="100"


### PR DESCRIPTION
## Summary
- Mejora accesibilidad del indicador de nivel de tanque con `aria-label`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82d0ebb5883308b1a854804cb9bbf