### PR TITLE
Refactor plant detail tabs into components

### DIFF
--- a/src/features/plantas/detail/PlantDetail.jsx
+++ b/src/features/plantas/detail/PlantDetail.jsx
@@ -11,39 +11,12 @@ import styles from '../../../styles/plant-detail.module.css';
 import Loading from '../../../components/feedback/Loading';
 import Empty from '../../../components/feedback/Empty';
 import Error from '../../../components/feedback/Error';
-
-const TabButton = ({ active, onClick, children }) => (
-  <button
-    className={`${uiStyles.btn} ${styles.tabButton} ${active ? styles.activeTab : ''}`}
-    onClick={onClick}
-    aria-selected={active}
-    role="tab"
-  >
-    {children}
-  </button>
-);
-
-const KpiCard = ({ value, label, unit = '' }) => (
-  <div className={styles.kpiCard}>
-    <div className={styles.kpiValue}>
-      {value}
-      {unit && <span className={styles.kpiUnit}>{unit}</span>}
-    </div>
-    <div className={styles.kpiLabel}>{label}</div>
-  </div>
-);
-
-const StatusChip = ({ status }) => {
-  const statusMap = {
-    ok: { label: 'Óptimo', className: styles.statusOk },
-    warning: { label: 'Advertencia', className: styles.statusWarning },
-    error: { label: 'Crítico', className: styles.statusError }
-  };
-  
-  const { label, className } = statusMap[status] || { label: 'Desconocido', className: styles.statusUnknown };
-  
-  return <span className={`${styles.statusChip} ${className}`}>{label}</span>;
-};
+import TabButton from './components/TabButton';
+import StatusChip from './components/StatusChip';
+import ResumenTab from './components/ResumenTab';
+import LecturasTab from './components/LecturasTab';
+import EstadoTab from './components/EstadoTab';
+import InfoTab from './components/InfoTab';
 
 const PlantDetail = () => {
   const { id } = useParams();
@@ -94,137 +67,13 @@ const PlantDetail = () => {
 
     switch (activeTab) {
       case 'resumen':
-        return (
-          <div className={styles.tabContent}>
-            <h3>Resumen de la Planta</h3>
-            <div className={styles.kpiGrid}>
-              <KpiCard 
-                value={plant.estado_actual || 'N/A'} 
-                label="Estado Actual" 
-                unit={plant.estado_actual === 'ok' ? '✓' : plant.estado_actual === 'warning' ? '⚠️' : '❌'} 
-              />
-              <KpiCard 
-                value={plant.caudal_actual || '0'} 
-                label="Caudal" 
-                unit="L/s" 
-              />
-              <KpiCard 
-                value={plant.nivel_cloro || '0'} 
-                label="Nivel de Cloro" 
-                unit="mg/L" 
-              />
-              <KpiCard 
-                value={plant.ph || '0'} 
-                label="pH" 
-              />
-            </div>
-            
-            <div className={styles.section}>
-              <h4>Últimas lecturas</h4>
-              {readings.length > 0 ? (
-                <div className={styles.readingsTable}>
-                  <div className={styles.tableHeader}>
-                    <div>Fecha</div>
-                    <div>Caudal (L/s)</div>
-                    <div>Cloro (mg/L)</div>
-                    <div>pH</div>
-                    <div>Estado</div>
-                  </div>
-                  {readings.map((reading, index) => (
-                    <div key={index} className={styles.tableRow}>
-                      <div>{new Date(reading.fecha).toLocaleString()}</div>
-                      <div>{reading.caudal}</div>
-                      <div>{reading.cloro}</div>
-                      <div>{reading.ph}</div>
-                      <div><StatusChip status={reading.estado} /></div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p>No hay lecturas recientes</p>
-              )}
-            </div>
-          </div>
-        );
-
+        return <ResumenTab plant={plant} readings={readings} />;
       case 'lecturas':
-        return (
-          <div className={styles.tabContent}>
-            <h3>Historial de Lecturas</h3>
-            <p>Aquí se mostrará el historial completo de lecturas de la planta.</p>
-            {/* Implementar tabla de lecturas con paginación */}
-          </div>
-        );
-
+        return <LecturasTab readings={readings} />;
       case 'estado':
-        return (
-          <div className={styles.tabContent}>
-            <h3>Estado del Sistema</h3>
-            <div className={styles.statusGrid}>
-              <div className={styles.statusCard}>
-                <h4>Bombas</h4>
-                <StatusChip status={plant.estado_bombas} />
-                <p>Última revisión: {new Date(plant.ultima_revision).toLocaleDateString()}</p>
-              </div>
-              <div className={styles.statusCard}>
-                <h4>Tanque de Almacenamiento</h4>
-                <div className={styles.progressContainer}>
-                  <div
-                    className={styles.progressBar}
-                    style={{ width: `${plant.nivel_tanque || 0}%` }}
-                    role="progressbar"
-                    aria-label="Nivel del tanque"
-                    aria-valuenow={plant.nivel_tanque || 0}
-                    aria-valuemin="0"
-                    aria-valuemax="100"
-                  >
-                    {plant.nivel_tanque || 0}%
-                  </div>
-                </div>
-              </div>
-              <div className={styles.statusCard}>
-                <h4>Calidad del Agua</h4>
-                <StatusChip status={plant.calidad_agua} />
-                <p>Último análisis: {new Date(plant.ultimo_analisis).toLocaleDateString()}</p>
-              </div>
-            </div>
-          </div>
-        );
-
+        return <EstadoTab plant={plant} />;
       case 'info':
-        return (
-          <div className={styles.tabContent}>
-            <h3>Información de la Planta</h3>
-            <div className={styles.infoGrid}>
-              <div className={styles.infoCard}>
-                <h4>Datos Generales</h4>
-                <p><strong>Nombre:</strong> {plant.nombre}</p>
-                <p><strong>Ubicación:</strong> {plant.ubicacion}</p>
-                <p><strong>Fuente de agua:</strong> {plant.fuente}</p>
-                <p><strong>Capacidad:</strong> {plant.capacidad} L/s</p>
-                <p><strong>Población servida:</strong> {plant.poblacion_servida.toLocaleString()} habitantes</p>
-              </div>
-              
-              <div className={styles.infoCard}>
-                <h4>Contacto</h4>
-                <p><strong>Operador:</strong> {plant.operador || 'No asignado'}</p>
-                <p><strong>Teléfono:</strong> {plant.telefono || 'N/A'}</p>
-                <p><strong>Email:</strong> {plant.email || 'N/A'}</p>
-                <p><strong>Horario de atención:</strong> {plant.horario_atencion || 'L-V 8:00-17:00'}</p>
-              </div>
-              
-              <div className={styles.infoCard}>
-                <h4>Estadísticas</h4>
-                <p><strong>En operación desde:</strong> {new Date(plant.fecha_operacion).getFullYear()}</p>
-                <p><strong>Inversión total:</strong> ${plant.inversion_total?.toLocaleString() || 'N/A'}</p>
-                <p><strong>Eficiencia:</strong> {plant.eficiencia || 'N/A'}%</p>
-                <p><strong>Último mantenimiento:</strong> {plant.ultimo_mantenimiento ? 
-                  new Date(plant.ultimo_mantenimiento).toLocaleDateString() : 'Nunca'}</p>
-              </div>
-            </div>
-          </div>
-        );
-
+        return <InfoTab plant={plant} />;
       default:
         return null;
     }

--- a/src/features/plantas/detail/components/EstadoTab.jsx
+++ b/src/features/plantas/detail/components/EstadoTab.jsx
@@ -1,0 +1,38 @@
+import StatusChip from './StatusChip';
+import styles from '../../../../styles/plant-detail.module.css';
+
+const EstadoTab = ({ plant }) => (
+  <div className={styles.tabContent}>
+    <h3>Estado del Sistema</h3>
+    <div className={styles.statusGrid}>
+      <div className={styles.statusCard}>
+        <h4>Bombas</h4>
+        <StatusChip status={plant.estado_bombas} />
+        <p>Última revisión: {new Date(plant.ultima_revision).toLocaleDateString()}</p>
+      </div>
+      <div className={styles.statusCard}>
+        <h4>Tanque de Almacenamiento</h4>
+        <div className={styles.progressContainer}>
+          <div
+            className={styles.progressBar}
+            style={{ width: `${plant.nivel_tanque || 0}%` }}
+            role="progressbar"
+            aria-label="Nivel del tanque"
+            aria-valuenow={plant.nivel_tanque || 0}
+            aria-valuemin="0"
+            aria-valuemax="100"
+          >
+            {plant.nivel_tanque || 0}%
+          </div>
+        </div>
+      </div>
+      <div className={styles.statusCard}>
+        <h4>Calidad del Agua</h4>
+        <StatusChip status={plant.calidad_agua} />
+        <p>Último análisis: {new Date(plant.ultimo_analisis).toLocaleDateString()}</p>
+      </div>
+    </div>
+  </div>
+);
+
+export default EstadoTab;

--- a/src/features/plantas/detail/components/InfoTab.jsx
+++ b/src/features/plantas/detail/components/InfoTab.jsx
@@ -1,0 +1,51 @@
+import styles from '../../../../styles/plant-detail.module.css';
+
+const InfoTab = ({ plant }) => (
+  <div className={styles.tabContent}>
+    <h3>Información de la Planta</h3>
+    <div className={styles.infoGrid}>
+      <div className={styles.infoCard}>
+        <h4>Datos Generales</h4>
+        <p><strong>Nombre:</strong> {plant.nombre}</p>
+        <p><strong>Ubicación:</strong> {plant.ubicacion}</p>
+        <p><strong>Fuente de agua:</strong> {plant.fuente}</p>
+        <p><strong>Capacidad:</strong> {plant.capacidad} L/s</p>
+        <p>
+          <strong>Población servida:</strong>{' '}
+          {plant.poblacion_servida.toLocaleString()} habitantes
+        </p>
+      </div>
+
+      <div className={styles.infoCard}>
+        <h4>Contacto</h4>
+        <p><strong>Operador:</strong> {plant.operador || 'No asignado'}</p>
+        <p><strong>Teléfono:</strong> {plant.telefono || 'N/A'}</p>
+        <p><strong>Email:</strong> {plant.email || 'N/A'}</p>
+        <p>
+          <strong>Horario de atención:</strong> {plant.horario_atencion || 'L-V 8:00-17:00'}
+        </p>
+      </div>
+
+      <div className={styles.infoCard}>
+        <h4>Estadísticas</h4>
+        <p>
+          <strong>En operación desde:</strong> {new Date(plant.fecha_operacion).getFullYear()}
+        </p>
+        <p>
+          <strong>Inversión total:</strong> ${plant.inversion_total?.toLocaleString() || 'N/A'}
+        </p>
+        <p>
+          <strong>Eficiencia:</strong> {plant.eficiencia || 'N/A'}%
+        </p>
+        <p>
+          <strong>Último mantenimiento:</strong>{' '}
+          {plant.ultimo_mantenimiento
+            ? new Date(plant.ultimo_mantenimiento).toLocaleDateString()
+            : 'Nunca'}
+        </p>
+      </div>
+    </div>
+  </div>
+);
+
+export default InfoTab;

--- a/src/features/plantas/detail/components/KpiCard.jsx
+++ b/src/features/plantas/detail/components/KpiCard.jsx
@@ -1,0 +1,13 @@
+import styles from '../../../../styles/plant-detail.module.css';
+
+const KpiCard = ({ value, label, unit = '' }) => (
+  <div className={styles.kpiCard}>
+    <div className={styles.kpiValue}>
+      {value}
+      {unit && <span className={styles.kpiUnit}>{unit}</span>}
+    </div>
+    <div className={styles.kpiLabel}>{label}</div>
+  </div>
+);
+
+export default KpiCard;

--- a/src/features/plantas/detail/components/LecturasTab.jsx
+++ b/src/features/plantas/detail/components/LecturasTab.jsx
@@ -1,0 +1,11 @@
+import styles from '../../../../styles/plant-detail.module.css';
+
+const LecturasTab = () => (
+  <div className={styles.tabContent}>
+    <h3>Historial de Lecturas</h3>
+    <p>Aquí se mostrará el historial completo de lecturas de la planta.</p>
+    {/* Implementar tabla de lecturas con paginación */}
+  </div>
+);
+
+export default LecturasTab;

--- a/src/features/plantas/detail/components/ResumenTab.jsx
+++ b/src/features/plantas/detail/components/ResumenTab.jsx
@@ -1,0 +1,63 @@
+import KpiCard from './KpiCard';
+import StatusChip from './StatusChip';
+import styles from '../../../../styles/plant-detail.module.css';
+
+const ResumenTab = ({ plant, readings }) => (
+  <div className={styles.tabContent}>
+    <h3>Resumen de la Planta</h3>
+    <div className={styles.kpiGrid}>
+      <KpiCard
+        value={plant.estado_actual || 'N/A'}
+        label="Estado Actual"
+        unit={
+          plant.estado_actual === 'ok'
+            ? '✓'
+            : plant.estado_actual === 'warning'
+            ? '⚠️'
+            : '❌'
+        }
+      />
+      <KpiCard
+        value={plant.caudal_actual || '0'}
+        label="Caudal"
+        unit="L/s"
+      />
+      <KpiCard
+        value={plant.nivel_cloro || '0'}
+        label="Nivel de Cloro"
+        unit="mg/L"
+      />
+      <KpiCard value={plant.ph || '0'} label="pH" />
+    </div>
+
+    <div className={styles.section}>
+      <h4>Últimas lecturas</h4>
+      {readings.length > 0 ? (
+        <div className={styles.readingsTable}>
+          <div className={styles.tableHeader}>
+            <div>Fecha</div>
+            <div>Caudal (L/s)</div>
+            <div>Cloro (mg/L)</div>
+            <div>pH</div>
+            <div>Estado</div>
+          </div>
+          {readings.map((reading, index) => (
+            <div key={index} className={styles.tableRow}>
+              <div>{new Date(reading.fecha).toLocaleString()}</div>
+              <div>{reading.caudal}</div>
+              <div>{reading.cloro}</div>
+              <div>{reading.ph}</div>
+              <div>
+                <StatusChip status={reading.estado} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p>No hay lecturas recientes</p>
+      )}
+    </div>
+  </div>
+);
+
+export default ResumenTab;

--- a/src/features/plantas/detail/components/StatusChip.jsx
+++ b/src/features/plantas/detail/components/StatusChip.jsx
@@ -1,0 +1,16 @@
+import styles from '../../../../styles/plant-detail.module.css';
+
+const StatusChip = ({ status }) => {
+  const statusMap = {
+    ok: { label: 'Óptimo', className: styles.statusOk },
+    warning: { label: 'Advertencia', className: styles.statusWarning },
+    error: { label: 'Crítico', className: styles.statusError },
+  };
+
+  const { label, className } =
+    statusMap[status] || { label: 'Desconocido', className: styles.statusUnknown };
+
+  return <span className={`${styles.statusChip} ${className}`}>{label}</span>;
+};
+
+export default StatusChip;

--- a/src/features/plantas/detail/components/TabButton.jsx
+++ b/src/features/plantas/detail/components/TabButton.jsx
@@ -1,0 +1,15 @@
+import uiStyles from '../../../../styles/ui.module.css';
+import styles from '../../../../styles/plant-detail.module.css';
+
+const TabButton = ({ active, onClick, children }) => (
+  <button
+    className={`${uiStyles.btn} ${styles.tabButton} ${active ? styles.activeTab : ''}`}
+    onClick={onClick}
+    aria-selected={active}
+    role="tab"
+  >
+    {children}
+  </button>
+);
+
+export default TabButton;


### PR DESCRIPTION
## Summary
- Extracted reusable UI elements (TabButton, KpiCard, StatusChip) into dedicated component files
- Split each plant detail tab into its own component and simplified `renderTabContent`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82e15cca0833092dbcdbe3c227443