### PR TITLE
feat(auth): add navbar and refine signin background

### DIFF
--- a/src/features/auth/AuthPage.jsx
+++ b/src/features/auth/AuthPage.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import AuthCard from './components/AuthCard';
+import Navbar from '../../components/Navbar';
 import styles from './auth.module.css';
 
 export default function AuthPage() {
   return (
-    <div className={styles.authPage}>
-      <main className={styles.authContainer}>
-        <AuthCard />
-      </main>
-    </div>
+    <>
+      <Navbar />
+      <div className={styles.authPage}>
+        <main className={styles.authContainer}>
+          <AuthCard />
+        </main>
+      </div>
+    </>
   );
 }

--- a/src/features/auth/auth.module.css
+++ b/src/features/auth/auth.module.css
@@ -8,13 +8,20 @@
   --border-color: #334155;
   --error: #f87171;
   --transition: all 0.2s ease;
+  --nav-h: 64px;
 }
 
 /* Page container */
 .authPage {
-  min-height: calc(100vh - 64px); /* Account for navbar */
+  min-height: calc(100vh - var(--nav-h)); /* Account for navbar */
+  margin-top: var(--nav-h);
   width: 100vw;
-  background: linear-gradient(135deg, var(--bg-dark) 0%, var(--primary) 100%);
+  background: radial-gradient(
+    circle at 25% 25%,
+    var(--primary-light) 0%,
+    var(--primary) 50%,
+    var(--bg-dark) 100%
+  );
   display: grid;
   place-items: center;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- show Navbar on sign-in page to enable navigation
- revamp sign-in background with radial gradient and spacing below nav

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a77da594188330947a9fb6e863aedf