### PR TITLE
feat: add empty state illustration for plants

### DIFF
--- a/public/empty-state.svg
+++ b/public/empty-state.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M32 2C32 2 12 22 12 34c0 11.046 8.954 22 20 22s20-10.954 20-22C52 22 32 2 32 2z" fill="#7dd3fc"/>
+  <circle cx="32" cy="36" r="10" fill="#e0f2fe"/>
+</svg>

--- a/src/features/plantas/Plantas.jsx
+++ b/src/features/plantas/Plantas.jsx
@@ -39,9 +39,17 @@ export default function Plantas() {
 
       {!selected && (
         <section className={styles.empty} aria-live="polite">
-          <div className={styles.emptyIcon} aria-hidden="true">💧</div>
+          <img
+            src="/empty-state.svg"
+            className={styles.emptyIcon}
+            alt=""
+            aria-hidden="true"
+          />
           <h2 className={styles.emptyTitle}>Explora plantas de agua potable</h2>
           <p className={styles.emptyHint}>Usa el selector de arriba para ver detalles de una planta.</p>
+          <a href="/dashboard" className={styles.viewAllButton}>
+            Ver todas las plantas
+          </a>
         </section>
       )}
 

--- a/src/features/plantas/plantas.module.css
+++ b/src/features/plantas/plantas.module.css
@@ -74,7 +74,8 @@
 }
 
 .emptyIcon {
-  font-size: 2.25rem;
+  width: 90px;
+  height: 90px;
   margin-bottom: 0.5rem;
   opacity: 0.9;
   display: inline-block;
@@ -95,6 +96,23 @@
   line-height: 1.5;
   max-width: 28rem;
   margin: 0 auto;
+}
+
+.viewAllButton {
+  display: inline-block;
+  margin-top: 1.25rem;
+  padding: 0.6rem 1.2rem;
+  background: #0ea5e9;
+  color: #eaf6ff;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.viewAllButton:hover {
+  background: #38bdf8;
+  transform: translateY(-2px);
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- replace empty state emoji with SVG illustration
- add 'Ver todas las plantas' button linking to dashboard
- style new button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e30e67208330abdd23e825613209