### PR TITLE
Add plant card grid with search filter

### DIFF
--- a/src/features/plantas/PlantCard.jsx
+++ b/src/features/plantas/PlantCard.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import styles from "./plantas.module.css";
+
+export default function PlantCard({ plant, onSelect, isSelected }) {
+  return (
+    <button
+      type="button"
+      className={`${styles.plantCard} ${isSelected ? styles.plantCardSelected : ""}`}
+      onClick={() => onSelect(plant.id)}
+    >
+      <span className={styles.plantIcon} aria-hidden="true">💧</span>
+      <span className={styles.plantName}>{plant.planta}</span>
+    </button>
+  );
+}

--- a/src/features/plantas/Plantas.jsx
+++ b/src/features/plantas/Plantas.jsx
@@ -2,11 +2,17 @@ import React, { useMemo, useState } from "react";
 import plantasRaw from "@data/plantas.json";
 import styles from "./plantas.module.css";
 import { normalizePlant } from "./normalizePlant.js";
+import PlantCard from "./PlantCard.jsx";
 
 export default function Plantas() {
   const [selectedId, setSelectedId] = useState("");
+  const [query, setQuery] = useState("");
 
   const plantas = useMemo(() => plantasRaw.map(normalizePlant), []);
+  const filtered = useMemo(
+    () => plantas.filter(p => p.planta.toLowerCase().includes(query.toLowerCase())),
+    [plantas, query]
+  );
   const selected = useMemo(() => plantas.find(p => p.id === selectedId), [plantas, selectedId]);
 
   function fmtInt(n) { return n == null ? "—" : n.toLocaleString("es-CO"); }
@@ -19,23 +25,29 @@ export default function Plantas() {
     <div className={styles.wrapper}>
       <h1 className={styles.title}>Selecciona una planta</h1>
 
-      <label htmlFor="plant-select" className={styles.label}>
-        Planta
+      <label htmlFor="plant-search" className={styles.label}>
+        Buscar planta
       </label>
-      <select
-        id="plant-select"
-        value={selectedId}
-        onChange={(e) => setSelectedId(e.target.value)}
-        className={styles.dropdown}
-        aria-label="Seleccionar planta"
-      >
-        <option value="">— Selecciona —</option>
-        {plantas.map((p) => (
-          <option key={p.id} value={p.id}>
-            {p.planta}
-          </option>
+      <input
+        id="plant-search"
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className={styles.search}
+        placeholder="Escribe para filtrar"
+        aria-label="Buscar planta"
+      />
+
+      <div className={styles.grid}>
+        {filtered.map((p) => (
+          <PlantCard
+            key={p.id}
+            plant={p}
+            onSelect={setSelectedId}
+            isSelected={p.id === selectedId}
+          />
         ))}
-      </select>
+      </div>
 
       {!selected && (
         <section className={styles.empty} aria-live="polite">
@@ -46,7 +58,7 @@ export default function Plantas() {
             aria-hidden="true"
           />
           <h2 className={styles.emptyTitle}>Explora plantas de agua potable</h2>
-          <p className={styles.emptyHint}>Usa el selector de arriba para ver detalles de una planta.</p>
+          <p className={styles.emptyHint}>Usa la búsqueda y selecciona una tarjeta para ver detalles de una planta.</p>
           <a href="/dashboard" className={styles.viewAllButton}>
             Ver todas las plantas
           </a>

--- a/src/features/plantas/plantas.module.css
+++ b/src/features/plantas/plantas.module.css
@@ -24,8 +24,8 @@
   color: var(--ui-text-muted, #9aa7b2);
 }
 
-/* --- Dropdown --- */
-.dropdown {
+/* --- Search --- */
+.search {
   width: 100%;
   padding: 0.7rem 0.85rem;
   font-size: 1rem;
@@ -33,30 +33,62 @@
   border: 1px solid rgba(255,255,255,0.12);
   background: rgba(12, 18, 32, 0.55);
   color: #eaf6ff;
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9L12 15L18 9' stroke='%23a0aec0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 0.85rem center;
-  background-size: 1rem;
   transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
-.dropdown:hover {
+.search:hover {
   border-color: rgba(0, 200, 255, 0.35);
 }
 
-.dropdown:focus {
+.search:focus {
   border-color: rgba(0, 200, 255, 0.55);
   background: rgba(20, 28, 46, 0.6);
   box-shadow: 0 0 0 3px rgba(0,200,255,0.15);
   outline: none;
 }
 
-.dropdown option {
-  background: #0c1a2f;
-  color: #e5eef6;
-  padding: 0.5rem;
+/* Grid of plant cards */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.plantCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.9rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #eaf6ff;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.plantCard:hover {
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateY(-2px);
+}
+
+.plantCardSelected {
+  border-color: rgba(0, 200, 255, 0.5);
+  background: rgba(0, 128, 255, 0.12);
+}
+
+.plantIcon {
+  font-size: 2rem;
+  margin-bottom: 0.25rem;
+}
+
+.plantName {
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.3;
 }
 
 /* --- Empty state --- */


### PR DESCRIPTION
## Summary
- add reusable PlantCard component with icon and name
- replace select with searchable grid of plant cards
- style plant grid and cards with hover effects

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e5f77614833086708b0cd649c168