### PR TITLE
Add minimal Next.js backend

### DIFF
--- a/backend/next.config.mjs
+++ b/backend/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/backend/src/pages/api/hello.ts
+++ b/backend/src/pages/api/hello.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ message: 'Hello from API' });
+}

--- a/backend/src/pages/index.tsx
+++ b/backend/src/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Backend Home</div>;
+}


### PR DESCRIPTION
## Summary
- scaffold minimal Next.js backend structure without Tailwind
- add example API route

## Testing
- `npm test`
- `npm run lint`
- `cd backend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9d86cc6c8833083fab2122b0d29bf