### PR TITLE
Use ROLES constant in login form

### DIFF
--- a/src/features/auth/components/LoginForm.jsx
+++ b/src/features/auth/components/LoginForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useAuth } from '../../../contexts/AuthContext';
+import { useAuth, ROLES } from '../../../contexts/AuthContext';
 import styles from '../auth.module.css';
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -30,7 +30,7 @@ export default function LoginForm() {
     setLoading(true);
     setTimeout(() => {
       // Simular sign-in
-      const user = { email, role: 'user' };
+      const user = { email, role: ROLES.USUARIO };
       signIn(user);
       // Redirigir
       const redirectTo = location.state?.from?.pathname || '/dashboard';


### PR DESCRIPTION
## Summary
- import ROLES from AuthContext in LoginForm
- use ROLES.USUARIO when creating sign-in user

## Testing
- `npm test`
- `npm run lint` *(fails: existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1fd340448330ad2e26f4bfa69972