### PR TITLE
Use navigation state for auth redirects

### DIFF
--- a/src/features/auth/ProtectedRoute.jsx
+++ b/src/features/auth/ProtectedRoute.jsx
@@ -7,8 +7,7 @@ export default function ProtectedRoute({ children, roles }) {
   const location = useLocation();
 
   if (!user) {
-    const redirectTo = encodeURIComponent(location.pathname + location.search);
-    return <Navigate to={`/login?redirectTo=${redirectTo}`} replace />;
+    return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   if (roles && !roles.includes(user.role)) {


### PR DESCRIPTION
## Summary
- redirect unauthenticated users to login with location state

## Testing
- `npm test`
- `npx eslint src/features/auth/ProtectedRoute.jsx src/features/auth/components/LoginForm.jsx`
- `npm run build`
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68aa209720f88330a0aae5f1652a365e