### PR TITLE
Remove redundant sign-in call in signup flow

### DIFF
--- a/src/features/auth/components/SignupForm.jsx
+++ b/src/features/auth/components/SignupForm.jsx
@@ -15,7 +15,7 @@ const ROLES = [
 ];
 
 export default function SignupForm() {
-  const { signIn, signUp } = useAuth();
+  const { signUp } = useAuth();
   const [nombre, setNombre] = useState('');
   const [email, setEmail] = useState('');
   const [rol, setRol] = useState('USUARIO');
@@ -49,7 +49,6 @@ export default function SignupForm() {
       // Simular registro y login
       const user = { name: nombre, email, role: rol };
       signUp(user);
-      signIn(user);
       navigate('/dashboard', { replace: true });
     }, 700);
   };


### PR DESCRIPTION
## Summary
- Avoid double sign-in by removing redundant `signIn` call in signup form
- Cleanup unused `signIn` import after refactor

## Testing
- `npm test`
- `npm run lint` *(fails: numerous lint errors in `backend/.next` build artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68aa21a4422c83308000aee84a3f4735