### PR TITLE
Use Jest for tests and clarify Node version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Aplicación web para el monitoreo de calidad de agua potable en zonas rurales.
 
 - Node.js 16+ (recomendado LTS)
 - npm o yarn
+- Node.js 18+ si se desea ejecutar las pruebas con `node --test`
 
 ## Instalación
 
@@ -53,6 +54,11 @@ npm run build
 # o
 yarn build
 ```
+
+## Pruebas
+
+- `npm test` ejecuta [Jest](https://jestjs.io/), compatible con Node.js 16+
+- Para usar el runner integrado de Node (`node --test`), se requiere Node.js 18+
 
 ## Características Implementadas
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.js']
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -27,6 +27,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "gh-pages": "^6.3.0",
     "globals": "^16.3.0",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "jest": "^29.7.0"
   }
 }

--- a/src/features/plantas/normalizePlant.test.js
+++ b/src/features/plantas/normalizePlant.test.js
@@ -1,18 +1,19 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, expect, test } from '@jest/globals';
 import { toNumber, normalizePlant } from './normalizePlant.js';
 
-test('toNumber converts strings to numbers and handles commas', () => {
-  assert.equal(toNumber('10'), 10);
-  assert.equal(toNumber('10,5'), 10.5);
-  assert.equal(toNumber('10.5'), 10.5);
-  assert.equal(toNumber(null), null);
-  assert.equal(toNumber(undefined), null);
-  assert.equal(toNumber('abc'), null);
-});
+describe('normalizePlant utilities', () => {
+  test('toNumber converts strings to numbers and handles commas', () => {
+    expect(toNumber('10')).toBe(10);
+    expect(toNumber('10,5')).toBe(10.5);
+    expect(toNumber('10.5')).toBe(10.5);
+    expect(toNumber(null)).toBeNull();
+    expect(toNumber(undefined)).toBeNull();
+    expect(toNumber('abc')).toBeNull();
+  });
 
-test('normalizePlant resolves caudalDiseno from multiple fields', () => {
-  assert.equal(normalizePlant({ caudaDiseño: '1,2' }).caudalDiseno, 1.2);
-  assert.equal(normalizePlant({ caudalDiseño: '2' }).caudalDiseno, 2);
-  assert.equal(normalizePlant({ caudalDiseno: '3' }).caudalDiseno, 3);
+  test('normalizePlant resolves caudalDiseno from multiple fields', () => {
+    expect(normalizePlant({ caudaDiseño: '1,2' }).caudalDiseno).toBe(1.2);
+    expect(normalizePlant({ caudalDiseño: '2' }).caudalDiseno).toBe(2);
+    expect(normalizePlant({ caudalDiseno: '3' }).caudalDiseno).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
- document Node.js 18+ requirement when using the built-in `node --test` runner
- switch the `npm test` script to Jest and add Jest config
- rewrite normalizePlant tests to run under Jest

## Testing
- `npm test` *(fails: Cannot find module '/workspace/app_rural_react/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2319bd7083309a0cc79b156347ab