### PR TITLE
Specify React versions in backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "24.3.0",


### PR DESCRIPTION
## Summary
- replace "latest" React dependencies with explicit ^18.2.0 versions for backend

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68aa240d5450833099f3fd7686098fc9