### PR TITLE
fix: align API routes and enable frontend CORS

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,7 +9,8 @@ import { requireAuth, requireRole } from './middleware/auth';
 const app = express();
 const prisma = new PrismaClient();
 
-app.use(cors({ origin: ['http://localhost:5173'], credentials: false }));
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5173';
+app.use(cors({ origin: FRONTEND_URL, credentials: true }));
 app.use(express.json());
 
 app.get('/health', (_req, res) => res.json({ ok: true }));

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -87,36 +87,36 @@ export const authApi = {
   },
   
   getProfile: async () => {
-    return apiRequest('/auth/me');
+    return apiRequest('/me');
   }
 };
 
 // Plantas API
 export const plantasApi = {
   getPlants: async () => {
-    return apiRequest('/api/plantas');
+    return apiRequest('/plantas');
   },
-  
+
   getPlant: async (id) => {
-    return apiRequest(`/api/plantas/${id}`);
+    return apiRequest(`/plantas/${id}`);
   },
-  
+
   createPlant: async (plantData) => {
-    return apiRequest('/api/plantas', {
+    return apiRequest('/plantas', {
       method: 'POST',
       body: plantData
     });
   },
-  
+
   updatePlant: async (id, plantData) => {
-    return apiRequest(`/api/plantas/${id}`, {
+    return apiRequest(`/plantas/${id}`, {
       method: 'PUT',
       body: plantData
     });
   },
-  
+
   deletePlant: async (id) => {
-    return apiRequest(`/api/plantas/${id}`, {
+    return apiRequest(`/plantas/${id}`, {
       method: 'DELETE'
     });
   }


### PR DESCRIPTION
## Summary
- remove /api prefix from plant endpoints in client and point profile to /me
- set configurable frontend origin in backend CORS with credentials

## Testing
- `npm test` *(fails: Cannot find module '/workspace/app_rural_react/node_modules/jest/bin/jest.js')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac2528305083308b162ef4a212e0df