### PR TITLE
refactor: centralize useAuth hook and roles export

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
-import { useAuth } from '../contexts/AuthContext';
+import useAuth from '../hooks/useAuth';
 import styles from '../styles/ui.module.css';
 
 const getInitials = (name, email) => {

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -144,3 +144,4 @@ export const AuthProvider = ({ children }) => {
 
 // Export the context for use with the useAuth hook
 export default AuthContext;
+export { ROLES };

--- a/src/features/auth/LoginPage.jsx
+++ b/src/features/auth/LoginPage.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../../contexts/AuthContext';
+import useAuth from '../../hooks/useAuth';
 
 export default function LoginPage() {
   const { login } = useAuth();

--- a/src/features/auth/ProtectedRoute.jsx
+++ b/src/features/auth/ProtectedRoute.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAuth } from '../../contexts/AuthContext';
+import useAuth from '../../hooks/useAuth';
 import { Navigate, useLocation } from 'react-router-dom';
 
 export default function ProtectedRoute({ children, roles }) {

--- a/src/features/auth/components/LoginForm.jsx
+++ b/src/features/auth/components/LoginForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useAuth } from '../../../contexts/AuthContext';
+import useAuth from '../../../hooks/useAuth';
 import styles from '../auth.module.css';
 import { useNavigate, useLocation } from 'react-router-dom';
 

--- a/src/features/auth/components/SignupForm.jsx
+++ b/src/features/auth/components/SignupForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useAuth } from '../../../contexts/AuthContext';
+import useAuth from '../../../hooks/useAuth';
 import styles from '../auth.module.css';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/features/dashboard/AdminPage.jsx
+++ b/src/features/dashboard/AdminPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useAuth } from '../../contexts/AuthContext';
+import useAuth from '../../hooks/useAuth';
 // Note: usersApi import is commented out until backend implementation is ready
 // import { usersApi } from '../../lib/apiClient';
 

--- a/src/features/home/Home.jsx
+++ b/src/features/home/Home.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../../contexts/AuthContext';
+import useAuth from '../../hooks/useAuth';
 import WaveBackground from './components/WaveBackground';
 import KpiCard from './components/KpiCard';
 import styles from '../../styles/home.module.css';

--- a/src/features/plantas/PlantasPage.jsx
+++ b/src/features/plantas/PlantasPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useAuth } from '../../contexts/AuthContext';
+import useAuth from '../../hooks/useAuth';
 import { plantasApi } from '../../lib/apiClient';
 
 export default function PlantasPage() {

--- a/src/features/plantas/detail/PlantDetail.jsx
+++ b/src/features/plantas/detail/PlantDetail.jsx
@@ -5,7 +5,8 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getPlant, getLatestReadings } from '../../../lib/apiClient';
-import { useAuth, ROLES } from '../../../contexts/AuthContext';
+import useAuth from '../../../hooks/useAuth';
+import { ROLES } from '../../../constants/roles';
 import uiStyles from '../../../styles/ui.module.css';
 import styles from '../../../styles/plant-detail.module.css';
 import Loading from '../../../components/feedback/Loading';

--- a/src/router/ProtectedRoute.jsx
+++ b/src/router/ProtectedRoute.jsx
@@ -1,5 +1,5 @@
 import { Navigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import useAuth from "../hooks/useAuth";
 
 export default function ProtectedRoute({ roles, children }) {
   const { isAuthenticated, user } = useAuth();


### PR DESCRIPTION
## Summary
- refactor imports to use dedicated useAuth hook
- re-export ROLES constant from auth context

## Testing
- `npm test` *(fails: Cannot find module '.../jest/bin/jest.js')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac2729a9c08330a7226dcd07e5d770