### PR TITLE
Rename login to signIn and add signUp

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -41,29 +41,29 @@ export const AuthProvider = ({ children }) => {
     return requiredRoles.includes(role);
   }, [user, role]);
 
-  // Login function
-  const login = useCallback(async (credentials) => {
+  // Sign in function
+  const signIn = useCallback(async (credentials) => {
     setError(null);
     setIsLoading(true);
-    
+
     try {
       const response = await authApi.login(credentials);
-      
+
       if (!response.token || !response.user) {
         throw new Error('Invalid response from server');
       }
-      
+
       const { token: authToken, user: userData } = response;
-      
+
       // Store token and user data
       localStorage.setItem(TOKEN_KEY, authToken);
       localStorage.setItem(USER_KEY, JSON.stringify(userData));
-      
+
       // Update state
       setUser(userData);
       setToken(authToken);
       setRole(userData.role || ROLES.USUARIO);
-      
+
       return userData;
     } catch (err) {
       const errorMessage = err.message || 'Error de autenticación';
@@ -73,6 +73,24 @@ export const AuthProvider = ({ children }) => {
       setIsLoading(false);
     }
   }, []);
+
+  // Sign up function
+  const signUp = useCallback(async (userData) => {
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      await authApi.register(userData);
+      // After successful registration, automatically sign in the user
+      return await signIn({ email: userData.email, password: userData.password });
+    } catch (err) {
+      const errorMessage = err.message || 'Error de registro';
+      setError(errorMessage);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [signIn]);
 
   // Load user from localStorage on mount
   useEffect(() => {
@@ -128,7 +146,8 @@ export const AuthProvider = ({ children }) => {
     isInitialized,
     isLoading,
     error,
-    login,
+    signIn,
+    signUp,
     logout,
     hasRole,
     hasAnyRole,

--- a/src/features/auth/LoginPage.jsx
+++ b/src/features/auth/LoginPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import useAuth from '../../hooks/useAuth';
 
 export default function LoginPage() {
-  const { login } = useAuth();
+  const { signIn } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -16,7 +16,7 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      await login({ email, password });
+      await signIn({ email, password });
       navigate('/plantas');
     } catch (err) {
       console.error('Login error:', err);

--- a/src/features/auth/components/LoginForm.jsx
+++ b/src/features/auth/components/LoginForm.jsx
@@ -28,14 +28,15 @@ export default function LoginForm() {
       return;
     }
     setLoading(true);
-    setTimeout(() => {
-      // Simular sign-in
-      const user = { email, role: 'user' };
-      signIn(user);
-      // Redirigir
+    try {
+      await signIn({ email, password });
       const redirectTo = location.state?.from?.pathname || '/dashboard';
       navigate(redirectTo, { replace: true });
-    }, 700);
+    } catch (err) {
+      setError(err.message || 'Error al iniciar sesión');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (

--- a/src/features/auth/components/SignupForm.jsx
+++ b/src/features/auth/components/SignupForm.jsx
@@ -15,7 +15,7 @@ const ROLES = [
 ];
 
 export default function SignupForm() {
-  const { signIn, signUp } = useAuth();
+  const { signUp } = useAuth();
   const [nombre, setNombre] = useState('');
   const [email, setEmail] = useState('');
   const [rol, setRol] = useState('USUARIO');
@@ -25,7 +25,7 @@ export default function SignupForm() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
     if (!nombre) {
@@ -45,13 +45,14 @@ export default function SignupForm() {
       return;
     }
     setLoading(true);
-    setTimeout(() => {
-      // Simular registro y login
-      const user = { name: nombre, email, role: rol };
-      signUp(user);
-      signIn(user);
+    try {
+      await signUp({ name: nombre, email, password, role: rol });
       navigate('/dashboard', { replace: true });
-    }, 700);
+    } catch (err) {
+      setError(err.message || 'Error al crear la cuenta');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- Rename AuthContext login method to signIn and add signUp for registration + auto-authentication
- Wire LoginPage, LoginForm and SignupForm to the new signIn/signUp context methods

## Testing
- ⚠️ `npm test` *(jest missing: Cannot find module 'node_modules/jest/bin/jest.js')*
- ⚠️ `npm run lint` *(Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac2a65ff7483308f86b898e9ea90b2