### PR TITLE
use constants for auth storage keys

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -1,11 +1,13 @@
-const BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
+import { TOKEN_KEY, USER_KEY } from '../constants/roles.js';
+
+const BASE_URL = import.meta.env?.VITE_API_URL || 'http://localhost:4000';
 
 /**
  * Helper function to get auth token from localStorage
  */
 const getAuthToken = () => {
   try {
-    return localStorage.getItem('token');
+    return localStorage.getItem(TOKEN_KEY);
   } catch (error) {
     console.error('Error accessing localStorage:', error);
     return null;
@@ -48,8 +50,8 @@ const apiRequest = async (endpoint, options = {}) => {
     // Handle 401 Unauthorized
     if (response.status === 401) {
       // Clear auth data and redirect to login
-      localStorage.removeItem('token');
-      localStorage.removeItem('user');
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(USER_KEY);
       window.dispatchEvent(new Event('unauthorized'));
       throw new Error('Sesión expirada. Por favor, inicia sesión nuevamente.');
     }
@@ -88,8 +90,8 @@ export const authApi = {
     try {
       await apiRequest('/auth/logout', { method: 'POST' });
     } finally {
-      localStorage.removeItem('token');
-      localStorage.removeItem('user');
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(USER_KEY);
     }
   },
   

--- a/src/lib/apiClient.test.js
+++ b/src/lib/apiClient.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { authApi, plantasApi } from './apiClient.js';
+import { TOKEN_KEY } from '../constants/roles.js';
+
+describe('apiClient authorization', () => {
+  beforeEach(() => {
+    // Mock fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({})
+    });
+
+    // Mock localStorage
+    const storage = {};
+    global.localStorage = {
+      getItem: jest.fn((key) => storage[key]),
+      setItem: jest.fn((key, value) => {
+        storage[key] = value;
+      }),
+      removeItem: jest.fn((key) => {
+        delete storage[key];
+      })
+    };
+  });
+
+  it('includes token in Authorization header for /me', async () => {
+    const token = 'test-token';
+    localStorage.setItem(TOKEN_KEY, token);
+
+    await authApi.getProfile();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, options] = fetch.mock.calls[0];
+    expect(options.headers.get('Authorization')).toBe(`Bearer ${token}`);
+  });
+
+  it('includes token in Authorization header for /plantas', async () => {
+    const token = 'test-token';
+    localStorage.setItem(TOKEN_KEY, token);
+
+    await plantasApi.getPlants();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, options] = fetch.mock.calls[0];
+    expect(options.headers.get('Authorization')).toBe(`Bearer ${token}`);
+  });
+});


### PR DESCRIPTION
## Summary
- import TOKEN_KEY and USER_KEY constants into apiClient and use them when reading and clearing auth data
- add tests verifying that Authorization header includes the token on `/me` and `/plantas` requests

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `node --input-type=module <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ac30956608833097bfa27ec887ceaf