### PR TITLE
Use error fallback and standardize backend messages

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -9,12 +9,12 @@ const router = Router();
 router.post('/register', async (req, res) => {
   const { name, email, password } = req.body || {};
   if (!name || !email || !password) {
-    return res.status(400).json({ error: 'name, email y password requeridos' });
+    return res.status(400).json({ message: 'name, email y password requeridos' });
   }
 
   const existing = await prisma.user.findUnique({ where: { email } });
   if (existing) {
-    return res.status(409).json({ error: 'Email ya registrado' });
+    return res.status(409).json({ message: 'Email ya registrado' });
   }
 
   const hashed = await bcrypt.hash(password, 10);
@@ -32,13 +32,13 @@ router.post('/register', async (req, res) => {
 
 router.post('/login', async (req, res) => {
   const { email, password } = req.body || {};
-  if (!email || !password) return res.status(400).json({ error: 'email y password requeridos' });
+  if (!email || !password) return res.status(400).json({ message: 'email y password requeridos' });
 
   const user = await prisma.user.findUnique({ where: { email } });
-  if (!user) return res.status(401).json({ error: 'Credenciales inválidas' });
+  if (!user) return res.status(401).json({ message: 'Credenciales inválidas' });
 
   const ok = await bcrypt.compare(password, user.password);
-  if (!ok) return res.status(401).json({ error: 'Credenciales inválidas' });
+  if (!ok) return res.status(401).json({ message: 'Credenciales inválidas' });
 
   const token = jwt.sign(
     { id: user.id, email: user.email, role: user.role },

--- a/backend/src/routes/plantas.ts
+++ b/backend/src/routes/plantas.ts
@@ -15,7 +15,7 @@ r.get('/', requireAuth, async (_req: AuthedRequest, res: Response) => {
 r.get('/:id', requireAuth, async (req: AuthedRequest, res: Response) => {
   const id = Number(req.params.id);
   const plant = await prisma.planta.findUnique({ where: { id } });
-  if (!plant) return res.status(404).json({ error: 'No encontrada' });
+  if (!plant) return res.status(404).json({ message: 'No encontrada' });
 
   // Datos adicionales simulados
   const enriched = {
@@ -51,11 +51,11 @@ r.get('/:id/lecturas', requireAuth, async (req: AuthedRequest, res: Response) =>
 r.post('/', requireAuth, async (req: AuthedRequest, res: Response) => {
   const role = req.user?.role;
   if (role !== 'ADMIN' && role !== 'OPERARIO') {
-    return res.status(403).json({ error: 'Prohibido' });
+    return res.status(403).json({ message: 'Prohibido' });
   }
   const { nombre, ubicacion, tipo } = req.body || {};
   if (!nombre || !ubicacion || !tipo) {
-    return res.status(400).json({ error: 'Faltan campos' });
+    return res.status(400).json({ message: 'Faltan campos' });
   }
   const p = await prisma.planta.create({ data: { nombre, ubicacion, tipo } });
   res.status(201).json(p);
@@ -66,9 +66,9 @@ r.delete('/:id', requireAuth, requireRole('ADMIN'), async (req: AuthedRequest, r
   const id = Number(req.params.id);
   try {
     await prisma.planta.delete({ where: { id } });
-    res.json({ ok: true });
+    res.json({ message: 'Planta eliminada' });
   } catch {
-    res.status(404).json({ error: 'No encontrada' });
+    res.status(404).json({ message: 'No encontrada' });
   }
 });
 

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -60,7 +60,7 @@ const apiRequest = async (endpoint, options = {}) => {
     const data = await response.json().catch(() => ({}));
     
     if (!response.ok) {
-      throw new Error(data.message || 'Error en la petición');
+      throw new Error(data.message || data.error || 'Error en la petición');
     }
 
     return data;


### PR DESCRIPTION
## Summary
- Use `data.error` as a fallback when building API error messages
- Return `{ message: '...' }` in backend auth and plant routes

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac33d4720c8330bedd93359e03ce8d