### PR TITLE
Restrict plant deletion to admins

### DIFF
--- a/src/features/plantas/PlantasPage.jsx
+++ b/src/features/plantas/PlantasPage.jsx
@@ -186,7 +186,7 @@ export default function PlantasPage() {
                 <p style={{ margin: '0.25rem 0', color: '#4b5563' }}>📍 {planta.ubicacion}</p>
                 <p style={{ margin: '0.25rem 0', color: '#4b5563' }}>🔧 {planta.tipo}</p>
                 
-                {hasAnyRole(['ADMIN', 'OPERARIO']) && (
+                {hasAnyRole(['ADMIN']) && (
                   <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem' }}>
                     <button
                       onClick={() => handleDelete(planta.id)}


### PR DESCRIPTION
## Summary
- Show plant delete button only to ADMIN users on PlantasPage

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac3598c5108330acdbc28c261aa753