### PR TITLE
Add plant update route and remove unused client

### DIFF
--- a/backend/src/routes/plantas.ts
+++ b/backend/src/routes/plantas.ts
@@ -61,6 +61,25 @@ r.post('/', requireAuth, async (req: AuthedRequest, res: Response) => {
   res.status(201).json(p);
 });
 
+// Actualizar (ADMIN u OPERARIO)
+r.put('/:id', requireAuth, async (req: AuthedRequest, res: Response) => {
+  const role = req.user?.role;
+  if (role !== 'ADMIN' && role !== 'OPERARIO') {
+    return res.status(403).json({ message: 'Prohibido' });
+  }
+  const id = Number(req.params.id);
+  const { nombre, ubicacion, tipo } = req.body || {};
+  if (!nombre || !ubicacion || !tipo) {
+    return res.status(400).json({ message: 'Faltan campos' });
+  }
+  try {
+    const p = await prisma.planta.update({ where: { id }, data: { nombre, ubicacion, tipo } });
+    res.json(p);
+  } catch {
+    res.status(404).json({ message: 'No encontrada' });
+  }
+});
+
 // Eliminar (solo ADMIN)
 r.delete('/:id', requireAuth, requireRole('ADMIN'), async (req: AuthedRequest, res: Response) => {
   const id = Number(req.params.id);

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -122,13 +122,6 @@ export const plantasApi = {
     });
   },
 
-  updatePlant: async (id, plantData) => {
-    return apiRequest(`/plantas/${id}`, {
-      method: 'PUT',
-      body: plantData
-    });
-  },
-
   deletePlant: async (id) => {
     return apiRequest(`/plantas/${id}`, {
       method: 'DELETE'


### PR DESCRIPTION
## Summary
- add secured PUT handler for updating plants
- drop unused updatePlant function from client API

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ac364b693483308ed8a4b80493a83f