### PR TITLE
feat: add acerca route

### DIFF
--- a/src/router/index.jsx
+++ b/src/router/index.jsx
@@ -11,6 +11,7 @@ const PlantDetail = lazy(() => import('../features/plantas/detail/PlantDetail'))
 const AdminPage = lazy(() => import('../features/dashboard/AdminPage'));
 const LoginPage = lazy(() => import('../features/auth/LoginPage'));
 const RegisterPage = lazy(() => import('../features/auth/RegisterPage'));
+const Acerca = lazy(() => import('../features/acerca'));
 const ProfilePage = lazy(() => import('../features/profile/ProfilePage'));
 const NotFoundPage = lazy(() => import('../components/feedback/NotFoundPage'));
 
@@ -21,7 +22,8 @@ const AppRoutes = () => (
     <Route path="/" element={<Home />} />
     <Route path="/login" element={<LoginPage />} />
     <Route path="/register" element={<RegisterPage />} />
-    
+    <Route path="/acerca" element={<Acerca />} />
+
     {/* Protected routes with layout */}
     <Route element={
       <ProtectedRoute>


### PR DESCRIPTION
## Summary
- lazy-load acerca feature and expose /acerca public route
- confirm navbar and footer links point to /acerca

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_68ac48052eb88330b9ca2f1c93896862