### PR TITLE
Render Navbar only in App

### DIFF
--- a/src/components/layout/AppLayout.jsx
+++ b/src/components/layout/AppLayout.jsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import Navbar from '../Navbar';
 import styles from '../../styles/layout.module.css';
 
 /**
  * AppLayout - Layout component that wraps all pages with a consistent structure
- * Renders the Navbar and a main content area with proper spacing for the fixed Navbar
+ * Provides a main content area with proper spacing for the fixed Navbar
  */
 const AppLayout = () => {
   return (
     <div className={styles.appContainer}>
-      <Navbar />
       <main className={styles.mainContent}>
         <Outlet />
       </main>


### PR DESCRIPTION
## Summary
- Remove Navbar rendering from AppLayout so Navbar only renders at App root
- Keep AppLayout focused on main content structure

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ac4b6d822883309c159b8cdea2cbe5