### PR TITLE
feat: make plant pages public

### DIFF
--- a/backend/src/routes/plantas.ts
+++ b/backend/src/routes/plantas.ts
@@ -1,18 +1,18 @@
-import { Router, Response } from 'express';
+import { Router, Response, Request } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { requireAuth, requireRole, AuthedRequest } from '../middleware/auth';
 
 const prisma = new PrismaClient();
 const r = Router();
 
-// Listar (auth requerido)
-r.get('/', requireAuth, async (_req: AuthedRequest, res: Response) => {
+// Listar plantas (público)
+r.get('/', async (_req: Request, res: Response) => {
   const all = await prisma.planta.findMany({ orderBy: { id: 'asc' } });
   res.json(all);
 });
 
-// Obtener una planta por ID
-r.get('/:id', requireAuth, async (req: AuthedRequest, res: Response) => {
+// Obtener una planta por ID (público)
+r.get('/:id', async (req: Request, res: Response) => {
   const id = Number(req.params.id);
   const plant = await prisma.planta.findUnique({ where: { id } });
   if (!plant) return res.status(404).json({ message: 'No encontrada' });
@@ -29,8 +29,8 @@ r.get('/:id', requireAuth, async (req: AuthedRequest, res: Response) => {
   res.json(enriched);
 });
 
-// Obtener últimas lecturas de una planta
-r.get('/:id/lecturas', requireAuth, async (req: AuthedRequest, res: Response) => {
+// Obtener últimas lecturas de una planta (público)
+r.get('/:id/lecturas', async (req: Request, res: Response) => {
   const id = Number(req.params.id);
   const limit = parseInt((req.query.limit as string) || '5', 10);
 

--- a/src/router/index.jsx
+++ b/src/router/index.jsx
@@ -24,6 +24,18 @@ const AppRoutes = () => (
     <Route path="/register" element={<RegisterPage />} />
     <Route path="/acerca" element={<Acerca />} />
 
+    {/* Public plantas routes with layout */}
+    <Route element={
+      <AppLayout>
+        <Suspense fallback={<Loading fullPage />}>
+          <Outlet />
+        </Suspense>
+      </AppLayout>
+    }>
+      <Route path="/plantas" element={<PlantasPage />} />
+      <Route path="/plantas/:id" element={<PlantDetail />} />
+    </Route>
+
     {/* Protected routes with layout */}
     <Route element={
       <ProtectedRoute>
@@ -40,25 +52,21 @@ const AppRoutes = () => (
           <Home />
         </ProtectedRoute>
       } />
-      
-      {/* Plantas routes */}
-      <Route path="/plantas" element={<PlantasPage />} />
-      <Route path="/plantas/:id" element={<PlantDetail />} />
-      
+
       {/* Profile routes */}
       <Route path="/profile" element={
         <ProtectedRoute>
           <ProfilePage />
         </ProtectedRoute>
       } />
-      
+
       {/* Admin routes */}
       <Route path="/admin" element={
         <ProtectedRoute roles={['ADMIN']}>
           <AdminPage />
         </ProtectedRoute>
       } />
-      
+
       {/* Catch-all route */}
       <Route path="*" element={<NotFoundPage />} />
     </Route>


### PR DESCRIPTION
## Summary
- move plant list and detail routes to the router's public block
- allow unauthenticated GET access to plant data endpoints

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c351b98833081ee0813dfe994c4