### PR TITLE
Map fallback plant fields and show source info

### DIFF
--- a/src/features/plantas/PlantasPage.jsx
+++ b/src/features/plantas/PlantasPage.jsx
@@ -19,7 +19,15 @@ export default function PlantasPage() {
       } catch (err) {
         console.error('Error loading plants:', err);
         setError('Mostrando datos de ejemplo.');
-        setList(localPlantas);
+        setList(
+          localPlantas.map((p) => ({
+            id: p.id,
+            nombre: p.planta,
+            ubicacion: p.vereda,
+            tipo: p.tipoPlanta,
+            fuente: p.fuente
+          }))
+        );
       } finally {
         setIsLoading(false);
       }
@@ -186,6 +194,9 @@ export default function PlantasPage() {
               >
                 <h4 style={{ marginTop: 0, marginBottom: '0.5rem' }}>{planta.nombre}</h4>
                 <p style={{ margin: '0.25rem 0', color: '#4b5563' }}>📍 {planta.ubicacion}</p>
+                {planta.fuente && (
+                  <p style={{ margin: '0.25rem 0', color: '#4b5563' }}>💧 {planta.fuente}</p>
+                )}
                 <p style={{ margin: '0.25rem 0', color: '#4b5563' }}>🔧 {planta.tipo}</p>
                 
                 {hasAnyRole(['ADMIN']) && (


### PR DESCRIPTION
## Summary
- Map local fallback plant data to expected list properties
- Display optional water source info on plant cards

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68acc07cf7f0833089565c5e98a58dab