### PR TITLE
Manejo de errores de conexión al cargar plantas

### DIFF
--- a/src/features/plantas/PlantasPage.jsx
+++ b/src/features/plantas/PlantasPage.jsx
@@ -10,28 +10,47 @@ export default function PlantasPage() {
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
-    const load = async () => {
-      setIsLoading(true);
-      try {
-        const data = await plantasApi.getPlants();
-        setList(data);
-        setError("");
-      } catch (err) {
-        console.error('Error loading plants:', err);
-        setError('Mostrando datos de ejemplo.');
-        setList(
-          localPlantas.map((p) => ({
-            id: p.id,
-            nombre: p.planta,
-            ubicacion: p.vereda,
-            tipo: p.tipoPlanta,
-            fuente: p.fuente
-          }))
-        );
-      } finally {
-        setIsLoading(false);
-      }
+  const load = async () => {
+    setIsLoading(true);
+
+    const setLocalData = () => {
+      setError('Mostrando datos de ejemplo.');
+      setList(
+        localPlantas.map((p) => ({
+          id: p.id,
+          nombre: p.planta,
+          ubicacion: p.vereda,
+          tipo: p.tipoPlanta,
+          fuente: p.fuente
+        }))
+      );
     };
+
+    try {
+      if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+        setLocalData();
+        return;
+      }
+
+      const data = await plantasApi.getPlants();
+      setList(data);
+      setError("");
+    } catch (err) {
+      const isConnectionError =
+        (typeof navigator !== 'undefined' && navigator.onLine === false) ||
+        err.name === 'TypeError';
+
+      if (isConnectionError) {
+        console.warn('Error de conexión al cargar plantas');
+      } else {
+        console.error('Error loading plants:', err);
+      }
+
+      setLocalData();
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   useEffect(() => {
     load();


### PR DESCRIPTION
## Summary
- Evita la llamada a la API cuando `navigator.onLine` es `false` y carga datos locales
- Usa `console.warn` en lugar de `console.error` para errores de conexión al obtener plantas

## Testing
- `npm test` *(falla: Cannot find module '/workspace/app_rural_react/node_modules/jest/bin/jest.js')*
- `npm install` *(falla: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68acc19674d483308887ca8c71eeee8b