### PR TITLE
feat: fallback to local data for plant detail

### DIFF
--- a/src/data/lecturas.json
+++ b/src/data/lecturas.json
@@ -1,0 +1,26 @@
+[
+  {
+    "plantId": "cascajal",
+    "fecha": "2024-01-01T12:00:00Z",
+    "caudal": 4.5,
+    "cloro": 0.6,
+    "ph": 7.2,
+    "estado": "ok"
+  },
+  {
+    "plantId": "cascajal",
+    "fecha": "2024-01-02T12:00:00Z",
+    "caudal": 4.2,
+    "cloro": 0.5,
+    "ph": 7.1,
+    "estado": "ok"
+  },
+  {
+    "plantId": "campoalegre",
+    "fecha": "2024-01-03T12:00:00Z",
+    "caudal": 3.8,
+    "cloro": 0.4,
+    "ph": 6.9,
+    "estado": "warning"
+  }
+]


### PR DESCRIPTION
## Summary
- handle API failures in PlantDetail with try/catch
- load plant data and readings from local JSON when API unavailable
- add sample readings dataset for offline usage

## Testing
- `npm test` *(fails: Cannot find module '/workspace/app_rural_react/node_modules/jest/bin/jest.js')*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68acc2da1dc8833093179540412b28cd