### PR TITLE
Avoid duplicate plant loading and disable StrictMode

### DIFF
--- a/src/features/plantas/PlantasPage.jsx
+++ b/src/features/plantas/PlantasPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import useAuth from '../../hooks/useAuth';
 import { plantasApi } from '../../lib/apiClient';
 import localPlantas from '../../data/plantas.json';
@@ -9,8 +9,9 @@ export default function PlantasPage() {
   const [form, setForm] = useState({ nombre: "", ubicacion: "", tipo: "" });
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const hasLoaded = useRef(false);
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setIsLoading(true);
 
     const setLocalData = () => {
@@ -50,11 +51,13 @@ export default function PlantasPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
+    if (hasLoaded.current) return;
     load();
-  }, []);
+    hasLoaded.current = true;
+  }, [load]);
 
   const handleCreate = async (e) => {
     e.preventDefault();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
@@ -8,14 +7,12 @@ import './styles/global.css';
 import AppRouter from './router';
 
 createRoot(document.getElementById('root')).render(
-    <StrictMode>
-      <AuthProvider>
-        <Router>
-          <Navbar />
-          <main className={uiStyles.mainContent}>
-            <AppRouter />
-          </main>
-        </Router>
-      </AuthProvider>
-    </StrictMode>
-  );
+  <AuthProvider>
+    <Router>
+      <Navbar />
+      <main className={uiStyles.mainContent}>
+        <AppRouter />
+      </main>
+    </Router>
+  </AuthProvider>
+);


### PR DESCRIPTION
## Summary
- Prevent duplicate plant loads by memoizing `load` and tracking initial run with a ref
- Remove `StrictMode` wrapper to avoid double mounting during development

## Testing
- `npm test` *(fails: Cannot find module '.../jest/bin/jest.js')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68acc55b03248330aaa80460605b6407